### PR TITLE
remove obsolete filter 'ergebnis-dienst.de'

### DIFF
--- a/easylistgermany/easylistgermany_adservers.txt
+++ b/easylistgermany/easylistgermany_adservers.txt
@@ -187,7 +187,6 @@
 ||eeewax.de^$third-party
 ||eletry.tk^$third-party
 ||elite-layer.de^$third-party
-||ergebnis-dienst.de^$third-party
 ||eroppc.com^$third-party
 ||erovation.com^$third-party
 ||eset-affiliate.de^$third-party


### PR DESCRIPTION
The filter was added after a forum-user (see https://forums.lanik.us/viewtopic.php?f=90&t=34460&p=109533&hilit=motorsport+total#p109533) reported it to publish ads on motorsport-total.com.

I do work for the company responsible for ergebnis-dienst.de and while we temporarily did serve ads via *.ad.ergebnis-dienst.de, we do not use that top level domain for any ad-related content.

Meanwhile that top-level domain does in ad-serving itself but hosts a couple sport-content solutions that are loaded on our clients pages within an iframe which gets blocked at the moment.

Thanks & Greetings