### PR TITLE
Add functionalclam.com to easylistgermany

### DIFF
--- a/easylistgermany/easylistgermany_thirdparty.txt
+++ b/easylistgermany/easylistgermany_thirdparty.txt
@@ -177,6 +177,7 @@
 ||fs-location.de/img/partner/
 ||fuckmetube.org^$subdocument,third-party
 ||fuckshow.org^$subdocument,third-party
+||functionalclam.com^$third-party
 ||g-stream.in/js/sms.js
 ||gameliebe.com/affiliate/$third-party
 ||gamercharts.com^$subdocument,third-party


### PR DESCRIPTION
... since we in Germany and Europe *cannot* be bound by DMCA. It's an USA only *ACT* and must not be enforced here.