### PR TITLE
M: added media.outnow.ch

### DIFF
--- a/easylistgermany/easylistgermany_specific_block.txt
+++ b/easylistgermany/easylistgermany_specific_block.txt
@@ -1373,6 +1373,7 @@
 ||outdoor-foren.de/images/vtlershop.de/
 ||outdoorseite.de/wp-content/uploads/*/trailsport-banner.jpg
 ||outnow.ch/Media/Site/Waerbig/Backgrounds/
+||media.outnow.ch/Site/Waerbig/
 ||overclockingstation.de/banner/
 ||ox.gassi-tv.de^
 ||ox.immobilo.de^


### PR DESCRIPTION
Ads are now served from the media.outnow.ch domain as well. 
E.g. https://media.outnow.ch/Site/Waerbig/Backgrounds/Aladdin/backs2.jpg