### PR TITLE
t-online.de###TAdBlockOverlayWrapper

### DIFF
--- a/easylistgermany/easylistgermany_specific_hide.txt
+++ b/easylistgermany/easylistgermany_specific_hide.txt
@@ -902,6 +902,7 @@ kalaydo.de###skyID
 aktionspreis.de###skyScraper
 apotheke-adhoc.de###skyWall
 t-online.de,wetter.info###sky_anz
+t-online.de###TAdBlockOverlayWrapper
 frimon.de###sky_right
 xboxdynasty.de###skyright
 ebay.at,ebay.ch,ebay.de###skyscrape


### PR DESCRIPTION
Popup, das AdBlock-Nutzer bittet, den AdBlocker auszuschalten (bspw. https://www.t-online.de/nachrichten/panorama/buntes-kurioses/id_88073190/zwischen-rheinland-pfalz-und-hessen-kinder-zwingen-ice-lokfuehrer-zu-notbremsung.html)