### PR TITLE
Add ablida.net

### DIFF
--- a/easylistgermany/easylistgermany_adservers.txt
+++ b/easylistgermany/easylistgermany_adservers.txt
@@ -4,6 +4,7 @@
 ||4strokemedia.com^$third-party
 ||85.114.133.62^$third-party
 ||a3h.de^$third-party
+||ablida.net^$third-party
 ||ablida-rotation.com^$third-party
 ||active-tracking.de^$third-party
 ||ad-generator.info^$third-party


### PR DESCRIPTION
Seen on https://www.handelsblatt.com. Also, I notice that ablida-rotation.com redirects to ablida.de, so should we maybe update that filter as well?