### PR TITLE
heise.de: block ad left-overs

### DIFF
--- a/easylistgermany/easylistgermany_specific_hide.txt
+++ b/easylistgermany/easylistgermany_specific_hide.txt
@@ -1502,6 +1502,7 @@ schweizer-illustrierte.ch##a[rel="sponsored"]
 andalusien-aktuell.es,sex4u.ch##a[rel^="sponsored"]
 kfz-steuer.de##a[style="position:relative; float:left; width:698px; height:63px; padding-left:28px; padding-right:0px; padding-top:14px; border:1pt solid #DADADC; background:#FFFFFF display:inline;"]
 ak-kurier.de##a[target="_new"][href^="inc/inc_link.php?id="]
+heise.de##a-ad
 weristdeinfreund.de##aside[id^="banner"]
 ww3.cad.de##body > table[width="100%"][border="0"]:first-child
 abload.de##center > table > tbody > tr > td[valign="bottom"][align="center"][style="width: 100%;"]


### PR DESCRIPTION
`<a-ad>` seems to be a [custom HTML element](https://developer.mozilla.org/docs/Web/Web_Components), I don't know if other sites happen to use it as well. If so, it would probably make sense to add the filter rule `##a-ad` to [easylist/easylist_general_hide.txt](https://github.com/easylist/easylist/blob/master/easylist/easylist_general_hide.txt) instead.