### PR TITLE
A: Banner ads on areadvd.de

### DIFF
--- a/easylistgermany/easylistgermany_specific_hide.txt
+++ b/easylistgermany/easylistgermany_specific_hide.txt
@@ -119,6 +119,9 @@ juve.de###banner_sidebar
 dreingau-zeitung.de,linguee.de###banner_top
 saiten.ch###banner_vertical
 queer.de###banneroben
+areadvd.de##img[referrerpolicy="unsafe-url"]
+areadvd.de##.span-3
+areadvd.de###JjiGAQd
 port01.com###bannerpos2
 queer.de###bannerrechts
 breakpoint.untergrund.net###banners


### PR DESCRIPTION
VPN to Germany, ABP + EL + EL Germany

Go to https://www.areadvd.de/news/eurosport-hd-sender-ab-august-nicht-mehr-bei-sky/

There are unblocked ads:

- on the left there is unblocked Panasonic ad (a[href="/panasonic_de"]) with some leftover from blocked ads
- on the right there is unblocked Outbrain-ish ad (img[referrerpolicy="unsafe-url"]) - the top unblocked ad is Taboola which filled request for allowlisting this position
- in the header

(img[referrer
![Screenshot 2022-08-31 at 09 46 47](https://user-images.githubusercontent.com/45878727/187623762-328fb677-059b-4368-ab4c-3de55bf2252e.png)
