### PR TITLE
A: `helpster.de`

### DIFF
--- a/easylistgermany/easylistgermany_specific_block.txt
+++ b/easylistgermany/easylistgermany_specific_block.txt
@@ -983,6 +983,7 @@ $stylesheet,subdocument,third-party,xmlhttprequest,domain=canna-power.to|canna.t
 ||tagblatt.de/CustomImages/Bannerkarusell/
 ||tageblatt.com.ar/banners/
 ||tah.de^*&tx_sfbanners_
+||target-video.com^$script,domain=helpster.de
 ||taschenlampen-forum.de/images/acebeam/
 ||taschenlampen-forum.de/images/armytek/
 ||taschenlampen-forum.de/images/gatzetec/


### PR DESCRIPTION
Hi, please add this filter `||target-video.com$script,domain=helpster.de` to stop this non related to this article ([for example](https://www.helpster.de/ghosten-was-ist-das-eigentlich_228876)) contend intrusive video ads `powered by targetvideo`
![image](https://user-images.githubusercontent.com/33602691/216607712-7a461f70-9de6-4ff4-958a-1692226d8d34.png)

Thank you in advance