### PR TITLE
M: https://www.finanzen.net/

### DIFF
--- a/easylistgermany/easylistgermany_specific_hide.txt
+++ b/easylistgermany/easylistgermany_specific_hide.txt
@@ -654,6 +654,7 @@ ak-kurier.de##.ad + #flashContent
 ak-kurier.de##.ad + .tdt
 ak-kurier.de##.ad + .uk-panel
 gebraucht-kaufen.de,mixed.de,raetsel-hilfe.de,spieletipps.de,swissmom.ch,watchtime.net,zeit.de##.ad-container
+finanzen.net##.ad-hint
 hallo-minden.de##.ad-info
 xdate.ch##.ad-item
 diegrenzgaenger.lu##.ad-listing


### PR DESCRIPTION
Hide ad leftover. The generic rule `##.ad-hint` [from EasyList](https://github.com/easylist/easylist/blob/a6713325cae4f825d4a744853902f29d115d0854/easylist/easylist_general_hide.txt#L6068) doesn't apply because of `@@||finanzen.net^$generichide`.

Site to test: https://www.finanzen.net/index/s&p_500