### PR TITLE
M: Update

### DIFF
--- a/easylistgermany/easylistgermany_specific_hide.txt
+++ b/easylistgermany/easylistgermany_specific_hide.txt
@@ -1432,7 +1432,6 @@ finanznachrichten.de##.smartbroker1
 stereoguide.de##.smartmag-widget-codes
 5-sms.com##.smsbox1
 5-sms.com##.smsbox2
-finanzen.net##.snapshot__trading
 finanzen100.de##.snippet--cta
 finanzen100.de##.snippet-container
 ladies.de##.sol-content


### PR DESCRIPTION
Hi, please remove the `finanzen.net##.snapshot__trading` filter from the list added on this commit https://github.com/easylist/easylistgermany/commit/7811a28363df95615da70d04b6ed92b78fce461f it hides from the functionality of the websites and the users can use the functions to buy and sell actions:
![image](https://user-images.githubusercontent.com/33602691/222184214-49ec2e3c-5cdd-4aa4-8949-faafc3322d2b.png)
 😇Thank you