### PR TITLE
M: https://www.sueddeutsche.de

### DIFF
--- a/easylistgermany/easylistgermany_specific_hide.txt
+++ b/easylistgermany/easylistgermany_specific_hide.txt
@@ -2602,6 +2602,7 @@ werkenntdenbesten.de##div[x-data="modules.ad()"]
 werkenntdenbesten.de##div[x-data="modules.ad()"] + span
 werkenntdenbesten.de##div[x-data^="modules.adMedia"]
 sueddeutsche.de##er-ad-slot
+sueddeutsche.de##footer[data-pay-team-id="end-of-article-footer"]
 ibooks.to##form[method="get"][action]:not([role="search"])
 reimmaschine.de##iframe[src="/more"]
 190.115.18.20,aniworld.to,s.to##iframe[style*="z-index: 2147483647"]


### PR DESCRIPTION
hide ad container (voucher codes etc.)

site to test: https://www.sueddeutsche.de/kultur/trump-armee-washington-kolumne-washington-d-c-li.3308561